### PR TITLE
Feat: Set the PrismJS types to the dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "carbonimg",
-  "version": "1.3.0-BETA",
+  "version": "1.3.1-BETA",
   "description": "A Carbon image generator from code",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -32,7 +32,8 @@
   "dependencies": {
     "canvas": "^2.11.0",
     "jest": "^29.4.2",
-    "prismjs": "^1.29.0"
+    "prismjs": "^1.29.0",
+    "@types/prismjs": "^1.26.0"
   },
   "devDependencies": {
     "@babel/helper-create-class-features-plugin": "^7.20.12",
@@ -40,7 +41,6 @@
     "@babel/preset-env": "^7.20.2",
     "@babel/preset-typescript": "^7.18.6",
     "@types/jest": "^29.4.0",
-    "@types/node": "^18.13.0",
-    "@types/prismjs": "^1.26.0"
+    "@types/node": "^18.13.0"
   }
 }


### PR DESCRIPTION
Set the PrismJS types to the `dependencies` and no longer in the `devDependencies`