### PR TITLE
Fix: Remove the big space behind the code

### DIFF
--- a/src/util/generateImage.ts
+++ b/src/util/generateImage.ts
@@ -143,7 +143,6 @@ export function draw(data: (string | Token)[], customTheme: ThemeBuilder, width:
 
     const canvas = createCanvas(width, evaluateHeight(data, width, customThemeProperties));
     const ctx = canvas.getContext("2d");
-    const charHeight = getCharHeight(ctx.measureText("]"));
 
     // Draw the background
     ctx.fillStyle = customThemeColors.window.backgroundColor;
@@ -159,6 +158,8 @@ export function draw(data: (string | Token)[], customTheme: ThemeBuilder, width:
         ImageSizes.marginTop * 2 +
         ImageSizes.headerHeight +
         ImageSizes.headerBottomMargin;
+
+    const charHeight = getCharHeight(ctx.measureText("]"));
 
     iterateThroughParts(ctx, data, customThemeColors, lastX, lastY, charHeight, width);
 


### PR DESCRIPTION
Resolve: #83 

### What was wrong with it?
Simply that the height of a character was not calculated from the font and its size. Therefore, the larger the font size, the smaller the space would have been, but conversely, the smaller the font size, the larger the space would have been.