### PR TITLE
Fix (Types): line options problems with render function

### DIFF
--- a/src/types/common.ts
+++ b/src/types/common.ts
@@ -12,14 +12,17 @@ export enum ImageSizes {
     lineNumberMarginLeft = 20
 }
 
-export interface Options extends Partial<LineOptions>{
+export interface Options extends Partial<OpenLineOptions>{
     theme?: ThemeBuilder;
     width?: number;
     title?: string;
 }
 
-export interface LineOptions {
+export interface OpenLineOptions {
     lineNumbers: boolean;
     firstLineNumber: number;
+}
+
+export interface LineOptions extends OpenLineOptions{
     lineNumberWidth: number;
 }


### PR DESCRIPTION
When you use the `render` function, you could pass the `lineNumberWidth` arguments while its private argument...