### PR TITLE
Fix (drawText): Unaligned code when line feed

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "carbonimg",
-  "version": "1.8.2-BETA",
+  "version": "1.8.3-BETA",
   "description": "A Carbon image generator from code",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/util/generateImage.ts
+++ b/src/util/generateImage.ts
@@ -19,27 +19,24 @@ function drawText(
         const charWidth = ctx.measureText(text[i] as string).width;
         const isBreakLine = text[i] === "\n";
 
-        if (text[i] === " " || isBreakLine) lastIndexSpace = i + 1;
+        if (text[i] === " " || isBreakLine)
+			lastIndexSpace = i + 1;
 
         if ((lastX + charWidth + ImageSizes.marginRight > width - options.lineNumberWidth) || isBreakLine) {
             const sentenceWidth = ctx.measureText(
                 text.slice(0, lastIndexSpace)
             ).width;
-            let cuttingIndex = i;
-            if (sentenceWidth + lastY + ImageSizes.marginRight <= width - options.lineNumberWidth) {
-                cuttingIndex = lastIndexSpace;
-            }
 
-            const printedText = text.slice(0, cuttingIndex)?.replace(/\n/g, "");
+			const printedText = text.slice(0, lastIndexSpace)?.replace(/\n/g, "");
             ctx.fillText(
                 printedText,
                 lastX - ctx.measureText(printedText).width,
                 lastY
             );
 
-            text = text.slice(cuttingIndex);
-            textLength -= cuttingIndex;
-            i -= cuttingIndex;
+            text = text.slice(lastIndexSpace);
+            textLength -= lastIndexSpace;
+            i -= lastIndexSpace;
 
             lastY += ImageSizes.textLineHeight + charHeight;
             lastX = backgroundPadding.left + charWidth;

--- a/src/util/sizes.ts
+++ b/src/util/sizes.ts
@@ -79,20 +79,17 @@ function getHeightOfAText(
         const charWidth = ctx.measureText(text[i] as string).width;
         const isBreakLine = text[i] === "\n";
 
-        if (text[i] === " " || isBreakLine) lastIndexSpace = i + 1;
+        if (text[i] === " " || isBreakLine)
+			lastIndexSpace = i + 1;
 
         if ((lastX + charWidth + ImageSizes.marginRight > width - lineNumberWidth) || isBreakLine) {
             const sentenceWidth = ctx.measureText(
                 text.slice(0, lastIndexSpace)
             ).width;
-            let cuttingIndex = i;
-            if (sentenceWidth + lastY + ImageSizes.marginRight <= width - lineNumberWidth) {
-                cuttingIndex = lastIndexSpace;
-            }
 
-            text = text.slice(cuttingIndex);
-            textLength -= cuttingIndex;
-            i -= cuttingIndex;
+            text = text.slice(lastIndexSpace);
+            textLength -= lastIndexSpace;
+            i -= lastIndexSpace;
 
             lastY += ImageSizes.textLineHeight + charHeight;
             lastX = ImageSizes.marginLeft + backgroundPadding.left + charWidth + lineNumberWidth;


### PR DESCRIPTION
Resolve: #144 

The problem was here because the line feed at the begin of the line. The variable `cuttingIndex` was one index too early, so the slice just sliced of 1 character...